### PR TITLE
Refactor Kafka receiver configuration for logs

### DIFF
--- a/completed/config.alloy
+++ b/completed/config.alloy
@@ -28,8 +28,10 @@ loki.write "http" {
 otelcol.receiver.kafka "default" {
   brokers          = ["kafka:9092"]
   protocol_version = "2.0.0"
-  topic           = "otlp"
-  encoding        = "otlp_proto"
+  logs {
+    topic    = "otlp"
+    encoding = "otlp_proto"
+  }
 
   output {
     logs    = [otelcol.processor.batch.default.input]


### PR DESCRIPTION
The Kafka receiver syntax has changed between Alloy releases, so the configuration for v1.9 differs from v1.11+ and v1.12+.The Kafka receiver expects topics to be configured inside a logs, metrics, or traces block, depending on what you're consuming.